### PR TITLE
fix: simplify auto-merge workflow for Renovate PRs

### DIFF
--- a/.github/workflows/auto-merge-renovate.yml
+++ b/.github/workflows/auto-merge-renovate.yml
@@ -5,98 +5,38 @@ permissions:
   pull-requests: write  # Allows updating PR status
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  workflow_run:
-    workflows: ["Main"]
-    types: [completed]
+  pull_request_target:
+    types: [opened, reopened]
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
 
     # Only run on Renovate PRs
-    if: github.event.pull_request.user.login == 'renovate[bot]' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request')
+    if: github.event.pull_request.user.login == 'renovate[bot]'
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Get PR number
-        id: pr
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          else
-            # For workflow_run events, extract PR number from the triggering workflow
-            PR_NUMBER=$(gh pr list --repo ${{ github.repository }} --head ${{ github.event.workflow_run.head_branch }} --json number --jq '.[0].number')
-            echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check if PR is from Renovate
-        id: check-renovate
-        run: |
-          PR_AUTHOR=$(gh pr view ${{ steps.pr.outputs.number }} --json author --jq '.author.login')
-          echo "author=$PR_AUTHOR" >> $GITHUB_OUTPUT
-
-          if [ "$PR_AUTHOR" = "renovate[bot]" ]; then
-            echo "is_renovate=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_renovate=false" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Check if major update
         id: check-major
-        if: steps.check-renovate.outputs.is_renovate == 'true'
         run: |
-          PR_TITLE=$(gh pr view ${{ steps.pr.outputs.number }} --json title --jq '.title')
+          PR_TITLE="${{ github.event.pull_request.title }}"
 
-          # Check if PR requires approval (major updates)
+          # Check if PR title contains "major" (skip auto-merge for major updates)
           if echo "$PR_TITLE" | grep -qiE '\bmajor\b'; then
             echo "is_major=true" >> $GITHUB_OUTPUT
-            echo "Major update detected - skipping auto-merge (requires manual approval)"
+            echo "⚠️  Major update detected - skipping auto-merge (requires manual approval)"
+            echo "PR: $PR_TITLE"
           else
             echo "is_major=false" >> $GITHUB_OUTPUT
+            echo "✅ Minor/patch update detected"
+            echo "PR: $PR_TITLE"
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Wait for CI to complete
-        if: steps.check-renovate.outputs.is_renovate == 'true' && steps.check-major.outputs.is_major == 'false'
-        run: |
-          echo "Waiting for CI checks to complete..."
-
-          # Wait up to 10 minutes for checks to complete
-          TIMEOUT=600
-          ELAPSED=0
-
-          while [ $ELAPSED -lt $TIMEOUT ]; do
-            # Check if all required checks have passed
-            CHECKS_STATUS=$(gh pr checks ${{ steps.pr.outputs.number }} --json state --jq 'map(select(.state != "SUCCESS")) | length')
-
-            if [ "$CHECKS_STATUS" = "0" ]; then
-              echo "All CI checks passed!"
-              exit 0
-            fi
-
-            echo "Waiting for checks... ($ELAPSED/$TIMEOUT seconds)"
-            sleep 10
-            ELAPSED=$((ELAPSED + 10))
-          done
-
-          echo "Timeout waiting for CI checks"
-          exit 1
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
-        if: steps.check-renovate.outputs.is_renovate == 'true' && steps.check-major.outputs.is_major == 'false'
+        if: steps.check-major.outputs.is_major == 'false'
         run: |
-          gh pr merge ${{ steps.pr.outputs.number }} --auto --squash
-          echo "✅ Auto-merge enabled for PR #${{ steps.pr.outputs.number }}"
+          gh pr merge ${{ github.event.pull_request.number }} --auto --squash --repo ${{ github.repository }}
+          echo "✅ Auto-merge enabled for PR #${{ github.event.pull_request.number }}"
+          echo "PR will be automatically merged once all CI checks pass"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-merge-renovate.yml
+++ b/.github/workflows/auto-merge-renovate.yml
@@ -16,8 +16,24 @@ jobs:
     if: github.event.pull_request.user.login == 'renovate[bot]'
 
     steps:
+      - name: Check labels
+        id: check-labels
+        run: |
+          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+
+          # Check if PR has both required labels
+          if echo "$LABELS" | jq -e 'contains(["renovate"]) and contains(["dependencies"])' > /dev/null; then
+            echo "has_labels=true" >> $GITHUB_OUTPUT
+            echo "✅ PR has required labels: renovate, dependencies"
+          else
+            echo "has_labels=false" >> $GITHUB_OUTPUT
+            echo "⚠️  PR missing required labels"
+            echo "Labels found: $LABELS"
+          fi
+
       - name: Check if major update
         id: check-major
+        if: steps.check-labels.outputs.has_labels == 'true'
         run: |
           PR_TITLE="${{ github.event.pull_request.title }}"
 
@@ -33,7 +49,7 @@ jobs:
           fi
 
       - name: Enable auto-merge
-        if: steps.check-major.outputs.is_major == 'false'
+        if: steps.check-labels.outputs.has_labels == 'true' && steps.check-major.outputs.is_major == 'false'
         run: |
           gh pr merge ${{ github.event.pull_request.number }} --auto --squash --repo ${{ github.repository }}
           echo "✅ Auto-merge enabled for PR #${{ github.event.pull_request.number }}"


### PR DESCRIPTION
Simplified the workflow to be more reliable:
- Use pull_request_target trigger (runs with write permissions)
- Remove complex gh CLI logic and waiting loops
- Simply enable auto-merge when PR opens
- Let GitHub handle waiting for CI and actual merging
- Only skip major updates (check PR title for "major" keyword)

This approach is cleaner and more reliable than the previous implementation.